### PR TITLE
Fixed a typo in ClubController, adding auth paths for ActivityController

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
@@ -62,7 +62,8 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
             .authenticated()
             .antMatchers("/clubactivities/**")
             .hasAnyRole("ADMIN", "CD")
-
+            .antMatchers("/activities/**")
+            .hasAnyRole("ADMIN","CD","YDP")
             .antMatchers("/clubs/**")
             .hasAnyRole("ADMIN", "CD")
             .antMatchers("/clubusers/**")

--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubController.java
@@ -70,7 +70,7 @@ public class ClubController {
      * @see ClubService#save(Club) ClubService.save(Club)
      */
     @PreAuthorize("hasAnyRole('ADMIN')")
-    @PostMapping(value = "/user/newClub",
+    @PostMapping(value = "/club/newClub",
             consumes = "application/json")
     public ResponseEntity<?> addNewClub(
             @Valid @RequestBody Club club) throws URISyntaxException


### PR DESCRIPTION
ClubController had a path with "user" instead of "club"
ActivityController was not usable due to missing auth paths, added.