### PR TITLE
adding an endpoint specifically for initial fetching of clubs

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubController.java
@@ -2,9 +2,12 @@ package com.lambdaschool.oktafoundation.controllers;
 
 import com.lambdaschool.oktafoundation.models.Club;
 import com.lambdaschool.oktafoundation.models.User;
+import com.lambdaschool.oktafoundation.repository.ClubRepository;
 import com.lambdaschool.oktafoundation.services.ClubService;
 import com.lambdaschool.oktafoundation.services.UserService;
+import com.lambdaschool.oktafoundation.views.ClubSummary;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +16,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
+import java.awt.desktop.OpenFilesEvent;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
+
 /**
  * The entry point for clients to access clubs data
  */
@@ -27,6 +33,10 @@ public class ClubController {
      */
     @Autowired
     private ClubService clubService;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
     /**
      * Returns a list of all clubs
      * <br>Example: <a href="http://localhost:2019/clubs/clubs"></a>
@@ -125,4 +135,13 @@ public class ClubController {
         clubService.delete(clubid);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+
+    @PreAuthorize("hasAnyRole('ADMIN','CD','YDP')")
+    @GetMapping(value = "/summary")
+    public ResponseEntity<?> getClubsSummary(){
+        List<ClubSummary> temp = clubRepository.getClubsSummary();
+        return new ResponseEntity<>(temp,HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/repository/ClubRepository.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/repository/ClubRepository.java
@@ -1,8 +1,22 @@
 package com.lambdaschool.oktafoundation.repository;
 
 import com.lambdaschool.oktafoundation.models.Club;
+import com.lambdaschool.oktafoundation.models.ClubActivities;
+import com.lambdaschool.oktafoundation.views.ClubSummary;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ClubRepository extends CrudRepository<Club, Long> {
+
+
+   @Query(
+           value = "select clubid,clubname from clubs",
+           nativeQuery = true
+   )
+   List<ClubSummary> getClubsSummary();
+
 
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/views/ClubSummary.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/views/ClubSummary.java
@@ -1,0 +1,6 @@
+package com.lambdaschool.oktafoundation.views;
+
+public interface ClubSummary {
+   long getClubid();
+   String getClubname();
+}


### PR DESCRIPTION
This is an endpoint to fetch a list of only clubnames and clubids, useful for getting initial list of clubs, this avoids fetching list of users and activities which might be long and yielding unnecessary data