### PR TITLE
fixing a bug where clubactivity -> memberreactions not cascading correctly

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/models/ClubActivities.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/ClubActivities.java
@@ -51,8 +51,10 @@ public class ClubActivities extends Auditable implements Serializable
      * connects clubactivities to the member reactions combination
      */
     @Column
-    @OneToMany
-    @JoinColumns({@JoinColumn(), @JoinColumn(name ="reactionid")})
+    @OneToMany(
+            mappedBy = "clubactivity",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+//    @JoinColumns({@JoinColumn(name=""), @JoinColumn(name ="")})
     //first join column used to be memberid, but regardless what to put there, we get a null field in memberreacctions
     //however, this doesn't break anything, but if this can be fixed that'll be good.
     private Set<MemberReactions> reactions = new HashSet<>();

--- a/src/main/java/com/lambdaschool/oktafoundation/models/MemberReactions.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/MemberReactions.java
@@ -52,7 +52,7 @@ public class MemberReactions extends Auditable implements Serializable
     @JoinColumns({
             @JoinColumn(name = "activityid"),
             @JoinColumn(name="clubid")})
-    @JsonIgnoreProperties(value="reactions")
+    @JsonIgnoreProperties(value="reactions",allowSetters = true)
     private ClubActivities clubactivity;
     /**
      * Default constructor used primarily by the JPA.


### PR DESCRIPTION
This patch fixes the issue when deleting a club or activity that has memberReactions to it, the delete request fails.