### PR TITLE
Csv upload endpoint added (beta, subject to minor changes); Club-member relation added.

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
@@ -51,6 +51,8 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
                 .antMatchers("/memberreactions/**").hasAnyRole("ADMIN","CD") //YDP cannot GET reactions
                 .antMatchers(HttpMethod.GET,"/members/**").authenticated()
                 .antMatchers("/members/**").hasAnyRole("CD","ADMIN")
+                .antMatchers("/csv/*").hasAnyRole("CD","ADMIN")
+                .antMatchers("/report/*").hasAnyRole("CD","ADMIN")
                 // *** Endpoints not specified above are automatically denied
                 .anyRequest()
                 .denyAll()

--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/CSVController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/CSVController.java
@@ -10,6 +10,7 @@ import org.h2.tools.Csv;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 import java.io.File;
@@ -35,8 +36,8 @@ public class CSVController {
 
 
     @PostMapping(value = "/upload")
-    public String handleCSVUpload(@RequestParam("file") File file) throws Exception{
-
+    public String handleCSVUpload(@RequestParam("file") MultipartFile mfile) throws Exception{
+        var file = mfile.getInputStream();
         var reader = new Scanner(file);
         var fields = new HashMap<String, Integer>();
         var clubcache = new HashMap<String, Club>();

--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/CSVController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/CSVController.java
@@ -1,0 +1,92 @@
+package com.lambdaschool.oktafoundation.controllers;
+
+import com.lambdaschool.oktafoundation.models.Member;
+import com.lambdaschool.oktafoundation.services.ClubService;
+import com.lambdaschool.oktafoundation.services.MemberService;
+import org.h2.tools.Csv;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.EntityManager;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Scanner;
+
+@RestController
+@RequestMapping("/csv")
+public class CSVController {
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private ClubService clubService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+
+    @PostMapping(value = "/upload")
+    public String handleCSVUpload(@RequestParam("file") File file) throws Exception{
+
+        var reader = new Scanner(file);
+        var fields = new HashMap<String, Integer>();
+//        var clubcache = new HashMap<String, Club>();
+        fields.put("clubname",0);
+        fields.put("memberid",1);
+        while (reader.hasNextLine()){
+            var line =  reader.nextLine().split(",");
+            if(line.length!=2){
+                return "Bad CSV format";
+            }
+            var isFieldsLine = line[0].equals("memberid") || line[0].equals("clubname");
+            if(isFieldsLine){
+                for (int i = 0; i<line.length; i++) {
+                    fields.put(line[i],i);
+                }
+                continue;
+            }
+            // We currently do not have club-member relationship, this is going to be confirmed with stakeholders. We're just adding new members to DB.
+            System.out.println("adding new member "+line[fields.get("memberid")]);
+            memberService.save(new Member(line[fields.get("memberid")]));
+
+//            System.out.println("adding new member"+line[fields.get("memberid")]+" to club "+line[fields.get("clubid")]);
+
+//            var mem
+
+//            Club club;
+//            if(clubcache.get(line[fields.get("clubname")])!=null) {
+//                club = clubcache.get(line[fields.get("clubname")]);
+//            } else {
+//                club = clubService.findClubByName(line[fields.get("clubname")]);
+//            }
+
+        }
+
+
+        return "OK";
+    }
+
+//    @GetMapping(value = "/download", produces = "text/csv")
+//    public ResponseEntity<?> serveCsv() throws Exception{
+//        var test = new Csv();
+//        test.setFieldDelimiter(',');
+//
+//        var q = entityManager.createQuery("select ");
+//
+//
+//
+//
+//        return new ResponseEntity<>()
+//
+//    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/lambdaschool/oktafoundation/models/Club.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/Club.java
@@ -63,6 +63,13 @@ public class Club
     @JsonIgnoreProperties(value = "club", allowSetters = true)
     private Set<ClubUsers> users = new HashSet<>();
 
+    @OneToMany(mappedBy = "club",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @JsonIgnoreProperties(value = "club", allowSetters = true)
+    private Set<ClubMembers> members = new HashSet<>();
+
+
     /**
      * The clubname (String). Cannot be null and must be unique
      */

--- a/src/main/java/com/lambdaschool/oktafoundation/models/ClubMembers.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/ClubMembers.java
@@ -1,0 +1,126 @@
+package com.lambdaschool.oktafoundation.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+/**
+ * The entity allowing interaction with the clubmembers table.
+ * The join table between clubs and members.
+ * <p>
+ * Table enforces a unique constraint of the combination of clubid and memberid.
+ * These two together form the primary key.
+ * <p>
+ * When you have a compound primary key, you must implement Serializable for Hibernate
+ * When you implement Serializable you must implement equals and hash code
+ */
+@Entity
+@Table(name = "clubmembers")
+@IdClass(ClubMembersId.class)
+public class ClubMembers
+    extends Auditable
+    implements Serializable
+{
+    /**
+     * 1/2 of the primary key (long) for clubmembers.
+     * Also is a foreign key into the clubs table
+     */
+    @Id
+    @ManyToOne
+    @NotNull
+    @JoinColumn(name = "clubid")
+    @JsonIgnoreProperties(value = {"members","activities","users"},
+        allowSetters = true)
+    private Club club;
+
+    /**
+     * 1/2 of the primary key (long) for clubmembers.
+     * Also is a foreign key into the members table
+     */
+    @Id
+    @ManyToOne
+    @NotNull
+    @JoinColumn(name = "member_table_id")
+    @JsonIgnoreProperties(value = {"clubs","reactions"},
+        allowSetters = true)
+    private Member member;
+
+    /**
+     * Default constructor used primarily by the JPA.
+     */
+    public ClubMembers()
+    {
+    }
+
+    public ClubMembers(Club c, Member m)
+    {
+        this.club = c;
+        this.member = m;
+    }
+
+
+    /**
+     * The getter for Club
+     *
+     * @return the complete club object associated with club member combination
+     */
+    public Club getClub()
+    {
+        return club;
+    }
+
+    /**
+     * Setter for club
+     *
+     * @param club change the club object associated with this club member combination to this one.
+     */
+    public void setClub(Club club)
+    {
+        this.club = club;
+    }
+
+    /**
+     * Getter for member
+     *
+     * @return the complete member object associated with this club member combination
+     */
+    public Member getMember()
+    {
+        return member;
+    }
+
+    /**
+     * Setter for member
+     *
+     * @param member change member object associated with this club member combination to this one.
+     */
+    public void setMember(Member member)
+    {
+        this.member = member;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof ClubMembers))
+        {
+            return false;
+        }
+        ClubMembers that = (ClubMembers) o;
+        return ((club == null) ? 0 : club.getClubid()) == ((that.club == null) ? 0 : that.club.getClubid()) &&
+            ((member == null) ? 0 : member.getMember_table_id()) == ((that.member == null) ? 0 : that.member.getMember_table_id());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        // return Objects.hash(club.getClubid(), member.getMemberid());
+        return 37;
+    }
+}

--- a/src/main/java/com/lambdaschool/oktafoundation/models/ClubMembersId.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/ClubMembersId.java
@@ -1,0 +1,95 @@
+package com.lambdaschool.oktafoundation.models;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+/**
+ * Class to represent the complex primary key for ClubMembers
+ */
+@Embeddable
+public class ClubMembersId
+    implements Serializable
+{
+
+    /**
+     * The id of the club
+     */
+    private long club;
+
+
+    /**
+     * The id of the member
+     */
+    private long member;
+
+    /**
+     * The default constructor required by JPA
+     */
+    public ClubMembersId()
+    {
+    }
+
+    /**
+     * Getter for the member id
+     *
+     * @return long the member id
+     */
+    public long getMember()
+    {
+        return member;
+    }
+
+    /**
+     * Setter for the member id
+     *
+     * @param member the new member id for this object
+     */
+    public void setMember(long member)
+    {
+        this.member = member;
+    }
+
+    /**
+     * Getter for the club id
+     *
+     * @return long the club id
+     */
+    public long getClub()
+    {
+        return club;
+    }
+
+    /**
+     * The setter for the club id
+     *
+     * @param club the new club id for this object
+     */
+    public void setClub(long club)
+    {
+        this.club = club;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        // boolean temp = (o.getClass() instanceof Class);
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        ClubMembersId that = (ClubMembersId) o;
+        return member == that.member &&
+            club == that.club;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 37;
+    }
+
+}

--- a/src/main/java/com/lambdaschool/oktafoundation/models/Member.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/Member.java
@@ -30,6 +30,10 @@ public class Member extends Auditable
     @JsonIgnoreProperties(value="member", allowSetters = true)
     public Set<MemberReactions> reactions = new HashSet<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnoreProperties(value= "member", allowSetters = true)
+    public Set<ClubMembers> clubs = new HashSet<>();
+
     /**
      * Default constructor used primarily by the JPA.
      */

--- a/src/main/java/com/lambdaschool/oktafoundation/repository/ClubMembersRepository.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/repository/ClubMembersRepository.java
@@ -1,0 +1,14 @@
+package com.lambdaschool.oktafoundation.repository;
+
+import com.lambdaschool.oktafoundation.models.ClubMembers;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+/**
+ * The CRUD repository connecting ClubUsers to the rest of the application
+ */
+public interface ClubMembersRepository extends CrudRepository<ClubMembers, Long> {
+
+    Optional<ClubMembers> findClubMembersByClub_ClubidAndMember_Memberid(Long cid, String memberid);
+}

--- a/src/main/java/com/lambdaschool/oktafoundation/repository/ClubRepository.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/repository/ClubRepository.java
@@ -19,4 +19,7 @@ public interface ClubRepository extends CrudRepository<Club, Long> {
    List<ClubSummary> getClubsSummary();
 
 
+   Optional<Club> findClubByClubname(String name);
+
+
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/services/ClubService.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/ClubService.java
@@ -46,4 +46,8 @@ public interface ClubService {
     void delete(long clubid);
 
     void deleteAll();
+
+    Club findClubByName(String name);
+
+
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/services/ClubServiceImpl.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/ClubServiceImpl.java
@@ -205,4 +205,12 @@ public class ClubServiceImpl implements ClubService{
     {
         clubrepos.deleteAll();
     }
+
+
+    @Override
+    public Club findClubByName(String name){
+        return clubrepos.findClubByClubname(name).orElseThrow(() -> new ResourceNotFoundException("Club with name " + name + " not found!"));
+    }
+
+
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/services/MemberService.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/MemberService.java
@@ -19,6 +19,8 @@ public interface MemberService {
      */
     Member findMemberById(long id);
 
+    Member findMemberByMemberId(String memberid);
+
     /**
      * Given a complete Member object, saves that Member in the database.
      * If a primary key is provided, the record is completely replaced.

--- a/src/main/java/com/lambdaschool/oktafoundation/services/MemberServiceImpl.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/MemberServiceImpl.java
@@ -39,6 +39,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public Member findMemberByMemberId(String memberid) throws ResourceNotFoundException {
+        return memberrepos.findMemberByMemberid(memberid).orElseThrow(() -> new ResourceNotFoundException("Member with memberid" + memberid + " not found"));
+    }
+
+
+    @Override
     public Member save(Member member) {
         Member newMember = new Member();
 
@@ -47,6 +53,13 @@ public class MemberServiceImpl implements MemberService {
                     .orElseThrow(() -> new ResourceNotFoundException("Member id " + member.getMember_table_id() + " not found!!"));
             newMember.setMember_table_id(member.getMember_table_id());
         }
+
+        // if the memberid is already in the database, return it, no new member is created.
+        var temp = memberrepos.findMemberByMemberid(member.getMemberid());
+        if (temp.isPresent()) {
+            return temp.get();
+        }
+
 
         newMember.setMemberid(member.getMemberid());
 


### PR DESCRIPTION
- Per the stakeholders meeting, it is convenient for us to have club-member relation, which might have usage in admin/cd dashboard. Additionally, this relation mirrors the csv format of clubname+memberid fields.
- csv can be uploaded via endpoint at POST /csv/upload?file={path_to_file}
   - supports first line being the field names as `clubname,memberid` or `memberid,clubname`
   - or without the first line defining the fields, if each line follows the data shape of  `clubname,memberid`