### PR TITLE
Fixing an overlooked logic flaw in memberReaction search

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/MemberReactionsController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/MemberReactionsController.java
@@ -194,9 +194,9 @@ public class MemberReactionsController {
 
         // adding filters for club activities
         if (ca != null && ca.size() > 0) {
-            res.append(" and cast((cast(clubid as varchar(255))||(cast(activityid as varchar(255))))as bigint) in (");
+            res.append(" and (clubid,activityid) in (");
             for (var e : ca) {
-                res.append(e.getClub().getClubid()).append(e.getActivity().getActivityid()).append(",");
+                res.append("(").append(e.getClub().getClubid()).append(",").append(e.getActivity().getActivityid()).append(")").append(",");
             }
             res.deleteCharAt(res.length() - 1);
             res.append(")");


### PR DESCRIPTION
the search query builder was concatenating clubID and activityID to act as a clubactivityID, but this was wrong since you could technically get this category of clashes "123"+"456" = "12"+"3456". It is now checking in the form of the pair (clubid,activityid) which should be equivalent to a ClubActivityID.